### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,4 @@ gem 'carrierwave'
 gem 'mini_magick'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
+gem 'jquery-turbolinks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,9 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -270,6 +273,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
+  jquery-turbolinks
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)

--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -1,0 +1,62 @@
+$(document).on('turbolinks:load', function() {
+
+  // ユーザー検索時に表示されるHTMLを生成
+    function buildSearchHTML(user) {
+      var html =
+        `<div class="chat-group-user clearfix">
+          <p class="chat-group-user__name">
+            ${user.name}</p>
+          <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加
+          </a>
+        </div>`;
+      return html
+    }
+  
+  // ユーザー追加ボタンクリック時に追加されるHTMLの生成
+    function buildMemberHTML(id, name) {
+      var html =
+      `<div class="chat-group-user clearfix" id=chat-group-user-${id}>
+        <input type="hidden" name="group[user_ids][]" value="${id}">
+        <p class="chat-group-user__name">${name}</p>
+        <a class="user-search-remove chat-group-user__btn chat-group-user__btn--remove" data-user-id="${id}">削除</a>
+      </div>`;
+      return html
+    }
+  
+
+  // インクリメンタルサーチ
+    $('#user-search-field').on('keyup', function() {
+      var input = $(this).val();
+      $.ajax({
+        type: 'GET',
+        url: '/groups/search',
+        data: { keyword: input },
+        dataType: 'json'
+      })
+      .done(function(users) {
+        var insertHTML = "";
+        users.forEach(function(user) {
+          insertHTML += buildSearchHTML(user);
+        });
+        $('#user-search-result').html(insertHTML);
+      })
+      .fail(function(data) {
+        alert("ユーザー検索に失敗しました");
+      });
+    });
+  
+  // メンバーの追加
+    $('#user-search-result').on('click', '.user-search-add', function(e) {
+      e.preventDefault();
+      var id = $(this).data('userId');
+      var name = $(this).data('userName');
+      var insertHTML = buildMemberHTML(id, name);
+      $('#chat-group-users').append(insertHTML);
+      $(this).parent('.chat-group-user').remove();
+    });
+    // メンバーの削除
+    $('#chat-group-users').on('click', '.user-search-remove', function() {
+      var id = $(this).data('userId');
+      $(`#chat-group-user-${id}`).remove();
+    })
+  });

--- a/app/assets/stylesheets/modules/chat.scss
+++ b/app/assets/stylesheets/modules/chat.scss
@@ -31,6 +31,7 @@
       color: $light_blue;
       float: right;
       height: 40px;
+      text-align: center;
       line-height: 40px;
       margin-top: 28px;
       padding: 0 20px;

--- a/app/assets/stylesheets/modules/side_bar.scss
+++ b/app/assets/stylesheets/modules/side_bar.scss
@@ -31,6 +31,7 @@
     height: calc(100vh - 100px);
     padding: 0 20px;
     overflow: scroll;
+    
     .group {
       box-sizing: border-box;
       padding: 20px 0 40px;
@@ -42,6 +43,7 @@
         color: $white;
         font-size: $side_group_message;
         margin-top: 5px;
+        margin-bottom: 40px;
       }
     }
   }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,18 @@
 class GroupsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :find_group_params, only: [:edit, :update]
+
+  def search
+    @users_except_me = User.where.not(id: current_user.id)
+    @users = @users_except_me.where('name LIKE(?)', "%#{params[:keyword]}%")
+    respond_to do |format|
+    format.json
+    end
+  end
+
+
   def index
+    @groups = current_user.groups.order(id: :DESC)
   end
 
   def new
@@ -10,10 +23,16 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
     if @group.save
-      redirect_to root_path, notice: 'グループを作成しました'
+      respond_to do |format|
+        format.html { redirect_to root_path, notice: "グループを作成しました" }
+        format.json
+      end
     else
       render :new
     end
+  end
+
+  def edit
   end
 
   def update
@@ -24,13 +43,17 @@ class GroupsController < ApplicationController
     end
   end
 
+
+
   private
+
   def group_params
+    user_ids = params[:group]["user_ids"]
+    user_ids << current_user.id.to_s
     params.require(:group).permit(:name, { :user_ids => [] })
   end
 
-  def set_group
+  def find_group_params
     @group = Group.find(params[:id])
   end
-  
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,6 @@
 class Group < ApplicationRecord
-  has_many :group_users
   has_many :messages
+  has_many :group_users, dependent: :destroy
   has_many :users, through: :group_users
 
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-  :recoverable, :rememberable, :trackable, :validatable
+  :recoverable, :rememberable, :validatable
 
 has_many :messages
 has_many :group_users

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -5,36 +5,38 @@
       %ul
         - group.errors.full_messages.each do |message|
           %li= message
+          
   .chat-group-form__field
     .chat-group-form__field--left
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  
   .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field{ class: "chat-group-form__input",placeholder: "検索するユーザー名を入力してください", autocomplete: "off" }
+        #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div id='chat-group-users'>
-        <div class='chat-group-user clearfix' id='chat-group-user-22'>
-        <input name='chat_group[user_ids][]' type='hidden' value='22'>
-        <p class='chat-group-user__name'>seo_kyohei</p>
-        </div>
-        </div>
+      #chat-group-users
+        .chat-group-user.clearfix
+          %p.chat-group-user__name
+            = current_user.name
+        - @group.users.each do |user|
+          - if user != current_user
+            .chat-group-user.clearfix{ id: "chat-group-user-#{user.id}" }
+              %input{ type: "hidden", name: "group[user_ids][]", value: user.id }
+              %p.chat-group-user__name
+                = user.name
+              - if user.id != current_user.id
+                %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove{ 'data-user-id': user.id }削除
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_group-form.haml
+++ b/app/views/groups/_group-form.haml
@@ -23,6 +23,7 @@
     .chat-group-form__field--right
       %input#user-search-field{ class: "chat-group-form__input",placeholder: "検索するユーザー名を入力してください", autocomplete: "off" }
       #user-search-result
+      
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー

--- a/app/views/groups/search.json.jbuilder
+++ b/app/views/groups/search.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -13,7 +13,8 @@
 
       .right-header
         .right-header__button
-          Edit
+          = link_to edit_group_path(@group) do
+            %p Edit
 
     .messages
       = render partial: 'messages/message', collection: @messages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resource :user, only: [:edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    collection do
+      get 'search'
+    end
   end
 end

--- a/db/migrate/20190613124158_devise_create_users.rb
+++ b/db/migrate/20190613124158_devise_create_users.rb
@@ -16,11 +16,11 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.0]
       t.datetime :remember_created_at
 
       ## Trackable
-      # t.integer  :sign_in_count, default: 0, null: false
-      # t.datetime :current_sign_in_at
-      # t.datetime :last_sign_in_at
-      # t.string   :current_sign_in_ip
-      # t.string   :last_sign_in_ip
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
 
       ## Confirmable
       # t.string   :confirmation_token


### PR DESCRIPTION
# WHY
グループを作成する際のユーザーの利便性を高める為に、ユーザー検索をインクリメンタルサーチで行えるようにする

# WHAT
1.作業用のブランチを作成する
 2. ルーティングなどAPI側の準備をする 
3. テキストフィールドを作成する 
4. テキストフィールドに入力されるたびにイベントが発火するようにする 
5. イベント時に非同期通信できるようにする 
6. 非同期通信の結果を得て、HTMLを作成する 
7. 5で作成したHTMLをビュー上に追加する 
8. エラー時の処理を行う

グループ新規作成が正常に行われる（追加したユーザー全員がグループのメンバーとなる）
グループの編集が行える（編集画面移行時に、既存ユーザーが削除されない）