### PR TITLE
database.ymlを編集する

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,6 @@ test:
 production:
   <<: *default
   database: chat-space_production
-  username: chat-space
-  password: <%= ENV['CHAT-SPACE_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
# WHY
Railsが起動しない原因はデータベースを作成していなかったためである。
データベースを作成する前に、アプリケーションのdatabase.ymlを編集する必要があるため。
# WHAT
database.ymlを編集する