### PR TITLE
unicorn.rbを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,5 @@ gem 'jquery-turbolinks'
 group :production do
   gem 'unicorn', '5.4.1'
 end
+
+gem 'libv8', '= 3.3.10.4'

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -11,7 +11,7 @@ working_directory app_path
 pid "#{app_path}/tmp/pids/unicorn.pid"
 
 #ポート番号を指定
-listen 3000
+listen "#{app_path}/tmp/sockets/unicorn.sock"
 
 #エラーのログを記録するファイルを指定
 stderr_path "#{app_path}/log/unicorn.stderr.log"


### PR DESCRIPTION
# WHY
WebサーバであるNginxを介した処理を行うため
Nginxはユーザーのリクエストに対して静的コンテンツの取り出し処理を行い、そして動的コンテンツの生成をアプリケーションサーバに依頼するためのもの
# WHAT
unicorn.rbの#ポート番号を指定を
listen "#{app_path}/tmp/sockets/unicorn.sock"に修正