### PR TITLE
therubyracerバージョンを指定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'therubyracer', platforms: :ruby
+gem 'therubyracer', '= 0.10.2', platforms: :ruby
 # gem 'mini_racer', platforms: :ruby
 
 # Use jquery as the JavaScript library


### PR DESCRIPTION
# WHY
herubyracerとlibv8は環境によってどのバージョンの組み合わせを入れるかがポイントだそうです。 
# WHAT
Gemfileに以下のようにtherubyracerとlibv8のバージョンを指定してbundle installすればよいようです。
gem 'therubyracer', '= 0.10.2', platforms: :ruby
gem 'libv8', '= 3.3.10.4'
