### PR TITLE
Capistranoの軽微な修正2

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,7 +11,7 @@ set :rbenv_ruby, '2.5.1' #カリキュラム通りに進めた場合、2.5.1か2
 
 # どの公開鍵を利用してデプロイするか
 set :ssh_options, auth_methods: ['publickey'],
-                  keys: ['~/.ssh/coronary_pem.pem']  ※例：~/.ssh/key_pem.pem
+                  keys: ['~/.ssh/coronary.pem'] 
 
 # プロセス番号を記載したファイルの場所
 set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }


### PR DESCRIPTION
# WHY
Capistranoを利用した自動デプロイを設定する際に、config/deploy.rbの記載が誤っていたため 自動デプロイがエラーなく実行できるようになることで作業効率の向上が見込める。
# WHAT
deploy.rbの記載を 　# どの公開鍵を利用してデプロイするか set :ssh_options, auth_methods: ['publickey'], keys: ['~/.ssh/coronary.pem']  に変更し、余計な記載を削除する。