### PR TITLE
デプロイ後ユーザー情報編集画面バグ修正

### DIFF
--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -7,7 +7,7 @@
         = link_to new_group_path do
           = fa_icon 'pencil-square-o', class: 'icon'
       %li.list
-        = link_to edit_users_path do
+        = link_to edit_user_path(current_user.id) do
           = fa_icon 'cog', class: 'icon'
   .groups
     .group

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,21 @@
+#account-page.account-page
+  .account-page__inner.clearfix
+    .account-page__inner--left.account-page__header
+      %h2 Edit Account
+      %h5 アカウントの編集
+      = link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'btn'
+      = link_to "トップページに戻る", :back, class: 'btn'
+    .account-page__inner--right.user-form
+      = form_for(current_user) do |f|
+        .field
+          .field-label
+            = f.label :name
+          .field-input
+            = f.text_field :name, autofocus: true
+        .field
+          .field-label
+            = f.label :email
+          .field-input
+            = f.email_field :email
+        .actions
+          = f.submit "Update", class: 'btn'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
-  resource :users, only: [:index, :edit, :update]
+  resources :users, only: [:edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
     namespace :api do


### PR DESCRIPTION
# WHY
デプロイ後にブラウザで表示されるWe're sorry, but something went wrong.のエラー画面を解決し、アプリを本番環境で使用可能にするために、トップ画面のユーザー情報編集画面のリンクから、誤ったページに飛んでしまうバグを修正した。（ローカル画面）

# WHAT
リンクのボタンを押すとApp/views/device/registrations/edit.html.hamlに飛んでいた。
これを、リンクの記述とルーティングの記述（resourcesがresourceになっていた点）を修正したところ、App/views/users/edit.html.hamlに正しく遷移するようになった。