### PR TITLE
投稿時間を日本時間で表示

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,5 +12,6 @@ module ChatSpace
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# WHY
投稿日時が日本時間で表示されるよう修正した。
チャットスペースを日本で使用することができる。

# WHAT
config/application.rbのmodule chatSpace内に
config.time_zone = 'Tokyo'
を追記した。